### PR TITLE
Remove "pkg-resources==0.0.0" from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ importlib-metadata==1.5.0
 more-itertools==8.2.0
 packaging==20.1
 pathlib2==2.3.5
-pkg-resources==0.0.0
 pluggy==0.13.1
 py==1.8.1
 pyparsing==2.4.6


### PR DESCRIPTION
`pkg-resources==0.0.0` may break things when running installs. As documented in the pypa repo: pypa/pip#4022, it is a bug where incorrect metadata about the packages is obtained.

It is safe to remove this from the requirements file and also from the environment used to create it.

This [askubuntu answer](https://askubuntu.com/questions/854249/pkg-resources-0-0-0-in-pip-freeze-bug) provides links to the related pages.
