### PR TITLE
Added config to run CI tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: python
+
+
+matrix:
+  include:
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.8
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.6.0
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.7.0
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=3.8.0
+
+
+install:
+  - |
+    # Manually installing pyenv and the required python version as travis does not support python builds on MacOS
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      brew update
+      brew install pyenv
+      eval "$(pyenv init -)"
+      pyenv install --skip-existing $PYTHON_VERSION
+      pyenv global $PYTHON_VERSION
+      pyenv shell $PYTHON_VERSION
+      pip install -U pip setuptools wheel py
+    fi
+      pip install -r requirements.txt
+
+
+script:
+    python -m pytest
+
+
+cache:
+  directories:
+    # Caching homebrew and pyenv directories to reduce build time (as they add several minutes otherwise)
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
+    - $HOME/.pyenv/versions
+
+
+before_cache:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi


### PR DESCRIPTION
Fixes #7 
### What does this PR do?
I have added a `.travis.yml` config to run CI tests on travis.

### Implementation
I added python 3.5 to 3.8 builds for linux, as they come pre-configured with travis the implementation is rather simple, installing the requirements and running pytest to run tests.

With MacOS, travis provides no out of the box way to run python builds. The installation begins with installing  pyenv through homebrew and loading the python from the version supplied in the `env`. Test script is same as linux. After the script pyenv and homebrew folders are cached to cut the 5+ minute build time they take. Tests were configured for python 3.6 to 3.8. 

### Notes
- This should be merged after merging #10 otherwise builds will fail due to the buggy entry in `requirements.txt`
- MacOS builds for python 3.5 were not implemented as pyenv can't build python3.5 on MacOS with native configuration. This is due to the required openssl headers not being available and causing python ssl extension build to fail. Seeing that python 3.5 EOL is September this year I decided to not work on it.
- Windows builds were not implemented as they again require implementing workarounds and writing windows scripts